### PR TITLE
pasting issue fix

### DIFF
--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -335,6 +335,7 @@ class Editor extends Component<Props> {
         if (e.attributes) {
           e.attributes.color = undefined;
           e.attributes.background = undefined;
+		  e.attributes["code-block"] = false;
         }
       });
       return delta;

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -335,7 +335,7 @@ class Editor extends Component<Props> {
         if (e.attributes) {
           e.attributes.color = undefined;
           e.attributes.background = undefined;
-		  e.attributes["code-block"] = false;
+          e.attributes["code-block"] = false;
         }
       });
       return delta;


### PR DESCRIPTION
pasting text from a code block should no longer format as a code block in the editor