### PR TITLE
 Refactor Tooltip to create embed options based on an injected config.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:dev": "rm -rf dist && tsc -p tsconfig.export.json --emitDeclarationOnly && ./node_modules/.bin/webpack --mode development",
     "build:force-dev": "rm -rf dist && ./node_modules/.bin/webpack --mode development",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "DEBUG=bobapost:* start-storybook -p 6006",
+    "storybook": "cross-env DEBUG=bobapost:* start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "visual-testing": "backstop test",
     "approve-visuals": "backstop approve"

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -13,6 +13,7 @@ import {
 import Tooltip from "./Tooltip";
 import Spinner from "./Spinner";
 import CustomNodesStyle from "./custom-nodes/CustomNodesStyle";
+import { defaultConfig } from './defaultConfig'
 
 import "quill/dist/quill.bubble.css";
 import "react-tenor/dist/styles.css";
@@ -426,6 +427,7 @@ class Editor extends Component<EditorProps> {
           <Toolbar ref={this.toolbarContainer} loaded={this.state.loaded} />
           {this.props.editable && (
             <Tooltip
+              config={defaultConfig}
               top={this.state.tooltipPostion.top}
               right={this.state.tooltipPostion.right}
               onInsertEmbed={({ type, embed }) => {

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -1,25 +1,10 @@
 import React, { Component, forwardRef } from "react";
 const TenorKeyboard = require("./TenorKeyboard").default;
 import classNames from "classnames";
+import { TooltipConfig, EmbedType } from "./config";
 
 // @ts-ignore
 import GifImage from "./img/gif.svg";
-// @ts-ignore
-import YouTubeIcon from "./img/yt_icon.svg";
-// @ts-ignore
-import TumblrIcon from "./img/tumblr_icon.svg";
-// @ts-ignore
-import TiktokIcon from "./img/tiktok.svg";
-// @ts-ignore
-import TwitterIcon from "./img/twitter.svg";
-// @ts-ignore
-import RedditIcon from "./img/reddit.svg";
-// @ts-ignore
-import PixivIcon from "./img/pixiv.svg";
-// @ts-ignore
-import InstagramIcon from "./img/instagram.svg";
-// @ts-ignore
-import VimeoIcon from "./img/vimeo.svg";
 
 import Quill from "quill";
 let QuillModule: typeof Quill;
@@ -30,6 +15,7 @@ if (typeof window !== "undefined") {
 const error = require("debug")("bobapost:editor:tooltip-error");
 
 class Tooltip extends Component<{
+  config: TooltipConfig;
   show: boolean;
   top: number | undefined;
   right: number | undefined;
@@ -45,6 +31,28 @@ class Tooltip extends Component<{
   imageInput = React.createRef<HTMLInputElement>();
 
   render() {
+    let embedButtons = this.props.config.enabledEmbeds.map((embed: EmbedType) => {
+      let Icon = embed.icon;
+      return (
+        <>
+          <button
+            className={"ql-" + embed.embedName}
+            onClick={() => {
+              // TODO: make a prettier input
+              let url = prompt("Gimme a " + embed.embedName + " url");
+              if (url) {
+                this.props.onInsertEmbed({
+                  type: embed.embedClass.blotName,
+                  embed: { url },
+                });
+              }
+            }}
+          >
+            <Icon key={embed.embedName} />
+          </button>
+        </>
+      )
+    });
     return (
       <>
         <div className="ql-bubble">
@@ -104,123 +112,7 @@ class Tooltip extends Component<{
             >
               <GifImage key="gif_image" />
             </button>
-            <button
-              className="ql-tweet"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a tweet url");
-                if (url) {
-                  this.props.onInsertEmbed({ type: "tweet", embed: url });
-                }
-              }}
-            >
-              <TwitterIcon key="twitter" />
-            </button>
-            <button
-              className="ql-reddit"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a reddit url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "reddit-embed",
-                    embed: { url },
-                  });
-                }
-              }}
-            >
-              <RedditIcon key="reddit" />
-            </button>
-            <button
-              className="ql-pixiv"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a pixiv url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "pixiv-embed",
-                    embed: { url },
-                  });
-                }
-              }}
-            >
-              <PixivIcon key="pixiv" />
-            </button>
-            <button
-              className="ql-instagram"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a instagram url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "instagram-embed",
-                    embed: { url },
-                  });
-                }
-              }}
-            >
-              <InstagramIcon key="instagram" />
-            </button>
-            <button
-              className="ql-tumblr"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a tumblr url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "tumblr-embed",
-                    embed: url,
-                  });
-                }
-              }}
-            >
-              <TumblrIcon key="tumblr_icon" />
-            </button>
-            <button
-              className="ql-tiktok"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a TikTok url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "tiktok-embed",
-                    embed: url,
-                  });
-                }
-              }}
-            >
-              <TiktokIcon key="tiktok_icon" />
-            </button>
-            <button
-              className="ql-youtube"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a YouTube url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "youtube-video",
-                    embed: url,
-                  });
-                }
-              }}
-            >
-              <YouTubeIcon key="youtube_icon" />
-            </button>
-            <button
-              className="ql-vimeo"
-              onClick={() => {
-                // TODO: make a prettier input
-                let url = prompt("Gimme a vimeo url");
-                if (url) {
-                  this.props.onInsertEmbed({
-                    type: "vimeo-embed",
-                    embed: { url },
-                  });
-                }
-              }}
-            >
-              <VimeoIcon key="vimeo" />
-            </button>
+            {embedButtons}
             <TenorKeyboard
               isOpen={this.state.tenorOpen}
               target={this.gifButton}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,15 @@
+import Quill from "quill";
+
+interface EmbedBase {
+    blotName : string;
+}
+
+export interface EmbedType {
+    embedName: string;
+    embedClass: EmbedBase;
+    icon: any;
+}
+  
+export interface TooltipConfig {
+    enabledEmbeds: EmbedType[];
+}

--- a/src/custom-nodes/TikTokEmbed.ts
+++ b/src/custom-nodes/TikTokEmbed.ts
@@ -169,11 +169,11 @@ class TikTokEmbed extends BlockEmbed {
     }
     return Link.sanitize(url); // eslint-disable-line import/no-named-as-default-member
   }
-}
 
-TikTokEmbed.blotName = "tiktok-embed";
-TikTokEmbed.tagName = "div";
-TikTokEmbed.className = "ql-tiktok-embed";
+  static blotName = "tiktok-embed";
+  static tagName = "div";
+  static className = "ql-tiktok-embed";
+}
 
 Icon["tiktok"] = TikTokEmbed.icon();
 

--- a/src/custom-nodes/TumblrEmbed.tsx
+++ b/src/custom-nodes/TumblrEmbed.tsx
@@ -163,11 +163,12 @@ class TumblrEmbed extends BlockEmbed {
     }
     return Link.sanitize(url); // eslint-disable-line import/no-named-as-default-member
   }
+
+  static blotName = "tumblr-embed";
+  static tagName = "div";
+  static className = "ql-tumblr-embed";
 }
 
-TumblrEmbed.blotName = "tumblr-embed";
-TumblrEmbed.tagName = "div";
-TumblrEmbed.className = "ql-tumblr-embed";
 
 Icon["tumblr"] = TumblrEmbed.icon();
 

--- a/src/custom-nodes/TweetEmbed.ts
+++ b/src/custom-nodes/TweetEmbed.ts
@@ -212,10 +212,10 @@ class TweetEmbed extends BlockEmbed {
     }
     return Link.sanitize(url); // eslint-disable-line import/no-named-as-default-member
   }
-}
 
-TweetEmbed.blotName = "tweet";
-TweetEmbed.tagName = "div";
-TweetEmbed.className = "ql-tweet";
+  static blotName = "tweet";
+  static tagName = "div";
+  static className = "ql-tweet";
+}
 
 export default TweetEmbed;

--- a/src/custom-nodes/YouTubeEmbed.ts
+++ b/src/custom-nodes/YouTubeEmbed.ts
@@ -95,10 +95,10 @@ class YouTubeEmbed extends BlockEmbed {
     }
     return Link.sanitize(url); // eslint-disable-line import/no-named-as-default-member
   }
-}
 
-YouTubeEmbed.blotName = "youtube-video";
-YouTubeEmbed.tagName = "div";
-YouTubeEmbed.className = "ql-youtube-video";
+  static blotName = "youtube-video";
+  static tagName = "div";
+  static className = "ql-youtube-video";
+}
 
 export default YouTubeEmbed;

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -1,0 +1,73 @@
+import { TooltipConfig } from "./config";
+
+import RedditEmbed from "./custom-nodes/RedditEmbed";
+import TweetEmbed from "./custom-nodes/TweetEmbed";
+import PixivEmbed from "./custom-nodes/PixivEmbed";
+import InstagramEmbed from "./custom-nodes/InstagramEmbed";
+import TumblrEmbed from "./custom-nodes/TumblrEmbed";
+import TikTokEmbed from "./custom-nodes/TikTokEmbed";
+import YouTubeEmbed from "./custom-nodes/YouTubeEmbed";
+import VimeoEmbed from "./custom-nodes/VimeoEmbed";
+
+// @ts-ignore
+import YouTubeIcon from "./img/yt_icon.svg";
+// @ts-ignore
+import TumblrIcon from "./img/tumblr_icon.svg";
+// @ts-ignore
+import TiktokIcon from "./img/tiktok.svg";
+// @ts-ignore
+import TwitterIcon from "./img/twitter.svg";
+// @ts-ignore
+import RedditIcon from "./img/reddit.svg";
+// @ts-ignore
+import PixivIcon from "./img/pixiv.svg";
+// @ts-ignore
+import InstagramIcon from "./img/instagram.svg";
+// @ts-ignore
+import VimeoIcon from "./img/vimeo.svg";
+
+export const defaultConfig: TooltipConfig = {
+    enabledEmbeds: [
+        {
+            embedName: "twitter",
+            embedClass: TweetEmbed,
+            icon: TwitterIcon
+        },
+        {
+            embedName: "reddit",
+            embedClass: RedditEmbed,
+            icon: RedditIcon
+        },
+        {
+            embedName: "pixiv",
+            embedClass: PixivEmbed,
+            icon: PixivIcon
+        },
+        {
+            embedName: "instagram",
+            embedClass: InstagramEmbed,
+            icon: InstagramIcon
+        },
+        {
+            embedName: "tumblr",
+            embedClass: TumblrEmbed,
+            icon: TumblrIcon
+        },
+        {
+            embedName: "tiktok",
+            embedClass: TikTokEmbed,
+            icon: TiktokIcon
+        },
+        {
+            embedName: "vimeo",
+            embedClass: VimeoEmbed,
+            icon: VimeoIcon
+        },
+        {
+            embedName: "youtube",
+            embedClass: YouTubeEmbed,
+            icon: YouTubeIcon
+        }
+
+    ]
+};


### PR DESCRIPTION
This paves the way for us to include embed types in the codebase without them automatically being available in the UI, reduces code duplication, reduces the chance of human error if embed types are spelled incorrectly in the tooltip code, and adds some additional type checking.

This also allows us to have different tooltips in different circumstances. For instance, we could test experimental embeds by rolling them out to !bobaland first, without affecting other boards.