### PR TITLE
Preventing multiple identical thumbnails during best effort embed.

### DIFF
--- a/src/custom-nodes/OEmbedBase.ts
+++ b/src/custom-nodes/OEmbedBase.ts
@@ -148,6 +148,26 @@ class OEmbed extends BlockEmbed {
     return;
   }
 
+  static chooseThumbnailImageLinks(
+    thumbnailLinks: any
+  ) {
+    const imageLinks = thumbnailLinks
+      .filter((link: any) => link.type.startsWith("image"));
+
+    if (imageLinks.length === 0) {
+      // If there are no images, don't display any images.
+      return [];
+    } else if (imageLinks[0].rel.includes("og")) {
+      // Otherwise, display the first image link. 
+      // If that's an Open Graph link, display all Open Graph links.
+      return imageLinks
+        .filter((link: any) => link.rel.includes("og"));
+    } else {
+      // If the first link isn't an Open Graph link, display only one preview image.
+      return [ imageLinks[0] ];
+    }
+  }
+
   static tryBestEffortLoad(
     node: HTMLDivElement,
     loadingDiv: HTMLElement,
@@ -156,13 +176,8 @@ class OEmbed extends BlockEmbed {
   ) {
     node.classList.add("best-effort");
     // Look for as much information as we can get in the data.
-    const imageUrls = (data.links?.thumbnail || [])
-      .filter((link: any) =>
-        link.type.startsWith("image")
-      )
-      .map((link: any) =>
-        link.href
-      );
+    const imageUrls = this.chooseThumbnailImageLinks(data.links?.thumbnail || [])
+      .map((link: any) => link.href);
     const iconUrl = data?.links?.icon?.find((link: any) =>
       link.type.startsWith("image")
     )?.href;

--- a/stories/1-Embeds.stories.tsx
+++ b/stories/1-Embeds.stories.tsx
@@ -328,6 +328,9 @@ const TEST_EMBEDS = [
   '{"embedHeight":"367.5","embedWidth":"500","url":"https://www.ndtv.com/offbeat/happy-new-year-2021-wishes-greetings-messages-images-pics-to-share-2346091"}',
   '{"embedHeight":"367.5","embedWidth":"500","url":"https://knowyourmeme.com/memes/moons-haunted"}',
   '{"embedHeight":"367.5","embedWidth":"500","url":"https://archiveofourown.org/works/28349940/chapters/69459594"}',
+  '{"embedHeight":"367.5","embedWidth":"500","url":"https://anarchism.space/@ExperimentV/105713537503551493"}',
+  '{"embedHeight":"367.5","embedWidth":"500","url":"https://tanoshimi.xyz/2016/11/29/yes-sadpanda-is-one-of-my-sources/"}',
+  '{"embedHeight":"367.5","embedWidth":"500","url":"https://www.traeume-aus-edelstahl.de/details.html?_filterartnr=hr007&_random=1120875411"}',
 ];
 
 export const BestEffortStory = () => (


### PR DESCRIPTION
Best effort embed now uses all Open Graph preview images if the first available preview image is "og",  otherwise it will use only the first available preview image to prevent a situation where there are multiple versions of a preview image meant for different things and it displays all of them.

I also added three test cases in embed stories, to test displaying multiple images, to test if only one version of a preview image shows up and to make sure it handles the situation where none of the images are available for preview. 